### PR TITLE
A bunch of commits to reduce the size of the container

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,11 +1,15 @@
-ARG COLLECTIONS_TO_REMOVE="fortinet cisco dellemc f5networks junipernetworks mellanox netapp"
 FROM registry.access.redhat.com/ubi9/ubi-minimal
-
 LABEL maintainer Validated Patterns <team-validated-patterns@redhat.com>
+
+ARG COLLECTIONS_TO_REMOVE="fortinet cisco dellemc f5networks junipernetworks mellanox netapp"
+ARG DNF_TO_REMOVE="dejavu-sans-fonts langpacks-core-font-en langpacks-core-en langpacks-en"
+ARG RPM_TO_FORCEFULLY_REMOVE="cracklib-dicts"
 
 USER root
 
 RUN microdnf install python3-pip make git-core tar vi -y && \
+microdnf remove -y $DNF_TO_REMOVE && \
+rpm -e --nodeps $RPM_TO_FORCEFULLY_REMOVE && \
 microdnf clean all && \
 rm -rf /var/cache/dnf && \
 curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64 && \

--- a/Containerfile
+++ b/Containerfile
@@ -15,15 +15,11 @@ curl -sLfO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.10.3/open
 tar xvf openshift-client-linux-4.10.3.tar.gz -C /usr/local/bin && \
 rm -rf openshift-client-linux-4.10.3.tar.gz 
 
-RUN pip3 install --no-cache-dir pip --upgrade && \
-pip3 install --no-cache-dir  ansible>=2.9 && \
+RUN pip3 install --no-cache-dir  ansible>=2.9 && \
 pip3 install --no-cache-dir kubernetes openshift boto3>=1.21 botocore>=1.24 awscli>=1.22 azure-cli>=2.34 gcloud --upgrade && \
 ansible-galaxy collection install kubernetes.core 
 
-RUN microdnf update -y python3-pip && \
-microdnf clean all && \
-rm -rf /var/cache/dnf && \
-mkdir -m 770 /pattern && \
+RUN mkdir -m 770 /pattern && \
 mkdir -m 770 -p /pattern/.ansible && \
 chown -R 1001.1001 /pattern 
 

--- a/Containerfile
+++ b/Containerfile
@@ -8,7 +8,7 @@ ARG OPENSHIFT_CLIENT_VERSION="4.10.3"
 
 USER root
 
-RUN microdnf install python3-pip make git-core tar vi -y && \
+RUN microdnf install -y python3-pip make git-core tar vi && \
 microdnf remove -y $DNF_TO_REMOVE && \
 rpm -e --nodeps $RPM_TO_FORCEFULLY_REMOVE && \
 microdnf clean all && \
@@ -27,7 +27,7 @@ rm -rf openshift-client-linux-$OPENSHIFT_CLIENT_VERSION.tar.gz  && rm -f /usr/lo
 # The size of the azure sdk is ridiculous because they keep old (and unused
 # APIs) around. We run this azure_sdk_trim.py to prune the unused APIs while
 # still maintaining a good compatibility level
-RUN pip3 install --no-cache-dir  ansible-core>=2.9 kubernetes openshift boto3>=1.21 botocore>=1.24 awscli>=1.22 azure-cli>=2.34 gcloud humanize --upgrade && \
+RUN pip3 install --no-cache-dir "ansible-core>=2.9" kubernetes openshift "boto3>=1.21" "botocore>=1.24" "awscli>=1.22" "azure-cli>=2.34" gcloud humanize --upgrade && \
 ansible-galaxy collection install kubernetes.core && \
 rm -rf /usr/local/lib/python3.9/site-packages/ansible_collections/$COLLECTIONS_TO_REMOVE && \
 curl -L -O https://raw.githubusercontent.com/clumio-code/azure-sdk-trim/main/azure_sdk_trim/azure_sdk_trim.py && \

--- a/Containerfile
+++ b/Containerfile
@@ -16,8 +16,7 @@ curl -sLfO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.10.3/open
 tar xvf openshift-client-linux-4.10.3.tar.gz -C /usr/local/bin && \
 rm -rf openshift-client-linux-4.10.3.tar.gz 
 
-RUN pip3 install --no-cache-dir  ansible>=2.9 && \
-pip3 install --no-cache-dir kubernetes openshift boto3>=1.21 botocore>=1.24 awscli>=1.22 azure-cli>=2.34 gcloud --upgrade && \
+RUN pip3 install --no-cache-dir  ansible-core>=2.9 kubernetes openshift boto3>=1.21 botocore>=1.24 awscli>=1.22 azure-cli>=2.34 gcloud --upgrade && \
 ansible-galaxy collection install kubernetes.core && \
 rm -rf /usr/local/lib/python3.9/site-packages/ansible_collections/$COLLECTIONS_TO_REMOVE
 

--- a/Containerfile
+++ b/Containerfile
@@ -4,6 +4,7 @@ LABEL maintainer Validated Patterns <team-validated-patterns@redhat.com>
 ARG COLLECTIONS_TO_REMOVE="fortinet cisco dellemc f5networks junipernetworks mellanox netapp"
 ARG DNF_TO_REMOVE="dejavu-sans-fonts langpacks-core-font-en langpacks-core-en langpacks-en"
 ARG RPM_TO_FORCEFULLY_REMOVE="cracklib-dicts"
+ARG OPENSHIFT_CLIENT_VERSION="4.10.3"
 
 USER root
 
@@ -16,9 +17,9 @@ curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/
 chmod +x /usr/local/bin/argocd && \
 curl -sSL -o /usr/local/bin/helm https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/helm/latest/helm-linux-amd64 && \
 chmod +x /usr/local/bin/helm && \
-curl -sLfO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.10.3/openshift-client-linux-4.10.3.tar.gz && \
-tar xvf openshift-client-linux-4.10.3.tar.gz -C /usr/local/bin && \
-rm -rf openshift-client-linux-4.10.3.tar.gz  && rm -f /usr/local/bin/kubectl && ln -sf /usr/local/bin/oc /usr/local/bin/kubectl
+curl -sLfO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OPENSHIFT_CLIENT_VERSION/openshift-client-linux-$OPENSHIFT_CLIENT_VERSION.tar.gz && \
+tar xvf openshift-client-linux-$OPENSHIFT_CLIENT_VERSION.tar.gz -C /usr/local/bin && \
+rm -rf openshift-client-linux-$OPENSHIFT_CLIENT_VERSION.tar.gz  && rm -f /usr/local/bin/kubectl && ln -sf /usr/local/bin/oc /usr/local/bin/kubectl
 
 # humanize is only needed for the trimming of the container
 # See https://github.com/Azure/azure-sdk-for-python/issues/11149

--- a/Containerfile
+++ b/Containerfile
@@ -14,7 +14,7 @@ curl -sSL -o /usr/local/bin/helm https://mirror.openshift.com/pub/openshift-v4/x
 chmod +x /usr/local/bin/helm && \
 curl -sLfO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.10.3/openshift-client-linux-4.10.3.tar.gz && \
 tar xvf openshift-client-linux-4.10.3.tar.gz -C /usr/local/bin && \
-rm -rf openshift-client-linux-4.10.3.tar.gz 
+rm -rf openshift-client-linux-4.10.3.tar.gz  && rm -f /usr/local/bin/kubectl && ln -sf /usr/local/bin/oc /usr/local/bin/kubectl
 
 # humanize is only needed for the trimming of the container
 # See https://github.com/Azure/azure-sdk-for-python/issues/11149

--- a/Containerfile
+++ b/Containerfile
@@ -1,3 +1,4 @@
+ARG COLLECTIONS_TO_REMOVE="fortinet cisco dellemc f5networks junipernetworks mellanox netapp"
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 
 LABEL maintainer Validated Patterns <team-validated-patterns@redhat.com>
@@ -17,7 +18,8 @@ rm -rf openshift-client-linux-4.10.3.tar.gz
 
 RUN pip3 install --no-cache-dir  ansible>=2.9 && \
 pip3 install --no-cache-dir kubernetes openshift boto3>=1.21 botocore>=1.24 awscli>=1.22 azure-cli>=2.34 gcloud --upgrade && \
-ansible-galaxy collection install kubernetes.core 
+ansible-galaxy collection install kubernetes.core && \
+rm -rf /usr/local/lib/python3.9/site-packages/ansible_collections/$COLLECTIONS_TO_REMOVE
 
 RUN mkdir -m 770 /pattern && \
 mkdir -m 770 -p /pattern/.ansible && \

--- a/Containerfile
+++ b/Containerfile
@@ -5,7 +5,7 @@ LABEL maintainer Validated Patterns <team-validated-patterns@redhat.com>
 
 USER root
 
-RUN microdnf install python3-pip make git tar vi -y && \
+RUN microdnf install python3-pip make git-core tar vi -y && \
 microdnf clean all && \
 rm -rf /var/cache/dnf && \
 curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64 && \

--- a/README.md
+++ b/README.md
@@ -12,22 +12,23 @@ Client Version: 4.10.3
 
 ### Installed Software
 
-| name | type | 
-|:----:|:-------:|
+|    name     |  type   |
+|:-----------:|:-------:|
 | python3-pip | package |
-| git | package |
-| helm | binary |
-| tar | package |
-| make | package |
-| argocd | binary |
-| ansible | pip |
-| kubernetes | pip |
-| openshift | pip |
-| boto3 | pip |
-| botocore | pip |
-| awscli | pip |
-| azure-cli | pip |
-| gcloud | pip |
+|  git-core   | package |
+|     vi      | package |
+|    helm     | binary  |
+|     tar     | package |
+|    make     | package |
+|   argocd    | binary  |
+|   ansible   |   pip   |
+| kubernetes  |   pip   |
+|  openshift  |   pip   |
+|    boto3    |   pip   |
+|  botocore   |   pip   |
+|   awscli    |   pip   |
+|  azure-cli  |   pip   |
+|   gcloud    |   pip   |
 
 
 ### The ansible-galaxy collection installed:


### PR DESCRIPTION
We went from 1.97 GB to 1.02GB and so we halve the size of the general image,
without removing any components.

- Stop installing pip from pip
- Remove some unneeded collections
- Run pip install in a single command
- Reduce the Azure sdk size impact
- Install git-core only
- Make kubectl a symlink to oc
- Add ARG variabls to remove some rpms
- Move the openshift_client version to a variable
- Fix some small hadolint warnings
- Fix package names indentation in README and add vi
