### PR TITLE
Prepare for ansible validated pattern

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -46,7 +46,7 @@ rm -rf /root/anaconda* /root/original-ks.cfg /usr/local/README
 # https://docs.ansible.com/ansible/latest/reference_appendices/config.html#collections-paths
 # otherwise whatever user openshift runs the container with won't find the collection
 RUN pip3 install --no-cache-dir "ansible-core>=2.9" kubernetes openshift "boto3>=1.21" "botocore>=1.24" "awscli>=1.22" "azure-cli>=2.34" gcloud humanize --upgrade && \
-ansible-galaxy collection install --collections-path /usr/share/ansible/collections kubernetes.core && \
+ansible-galaxy collection install --collections-path /usr/share/ansible/collections kubernetes.core redhat_cop.controller_configuration && \
 rm -rf /usr/local/lib/python3.9/site-packages/ansible_collections/$COLLECTIONS_TO_REMOVE && \
 curl -L -O https://raw.githubusercontent.com/clumio-code/azure-sdk-trim/main/azure_sdk_trim/azure_sdk_trim.py && \
 python azure_sdk_trim.py && rm azure_sdk_trim.py && pip3 uninstall -y humanize

--- a/Containerfile
+++ b/Containerfile
@@ -14,7 +14,7 @@ ARG YQ_VERSION="4.30.7"
 
 USER root
 
-RUN microdnf install -y python3-pip make git-core tar vi jq which findutils diffutils && \
+RUN microdnf --disableplugin=subscription-manager install -y python3-pip make git-core tar vi jq which findutils diffutils && \
 microdnf remove -y $DNF_TO_REMOVE && \
 rpm -e --nodeps $RPM_TO_FORCEFULLY_REMOVE && \
 microdnf clean all && \

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ versions: ## Prints the versions of most tools inside the container
 		echo '* Python: '; python --version ; \
 		echo '* Ansible: '; ansible --version ; \
 		echo '* kubernetes.core: '; ansible-galaxy collection list | grep kubernetes.core ; \
+		echo '* redhat_cop.controller_configuration: '; ansible-galaxy collection list | grep redhat_cop.controller_configuration ; \
 		echo '* diff: '; diff --version ; \
 		echo '* find: '; find --version"
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Client Version: 4.10.3
 | ansible-collections |
 | ------------------- |
 | kubernetes.core |
+| redhat_cop.controller_configuration |
 
 ### Usage
 **Pull the image**


### PR DESCRIPTION
1) Include redhat_cop.controller_configuration collection, including with docs and help text
2) Explicitly disable subscription-manager plugin in microdnf in order to avoid pulling in wrong pacakges in some unusual configurations (extra packages beyond ubi-9 are not required here)