### PR TITLE
Cleanups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 updates:
   - package-ecosystem: "docker"

--- a/.github/linters/.hadolint.yml
+++ b/.github/linters/.hadolint.yml
@@ -1,8 +1,10 @@
 ignored:
-  # Always tag the version of an image explicitly
-  - DL3006
   # Last USER should not be root
   - DL3002 
+  # Always tag the version of an image explicitly
+  - DL3006
+  # Using latest is prone to errors if the image will ever update. Pin the version explicitly to a release tag
+  - DL3007
   # Specify version with `dnf install -y <package>-<version>`.
   - DL3041 
   # Pin versions in pip. Instead of `pip install <package>` use `pip install

--- a/.github/linters/.hadolint.yml
+++ b/.github/linters/.hadolint.yml
@@ -1,0 +1,9 @@
+ignored:
+  # Always tag the version of an image explicitly
+  - DL3006
+  # Last USER should not be root
+  - DL3002 
+  # Specify version with `dnf install -y <package>-<version>`.
+  - DL3041 
+  # Pin versions in pip. Instead of `pip install <package>` use `pip install
+  - DL3013

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -1,3 +1,4 @@
+---
 name: "Container build and test"
 on: [push, pull_request]
 

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -1,0 +1,29 @@
+---
+name: Super linter
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    # Name the Job
+    name: Super linter
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      ################################
+      # Run Linter against code base #
+      ################################
+      - name: Lint Code Base
+        uses: github/super-linter/slim@v4
+        env:
+          VALIDATE_ALL_CODEBASE: true
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # These are the validation we disable atm

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ARG TITLE="utility-container"
 ARG DESCRIPTION="Pattern Utility Container"

--- a/Containerfile
+++ b/Containerfile
@@ -77,7 +77,10 @@ ansible-galaxy collection install --collections-path /usr/share/ansible/collecti
 rm -rf /usr/local/lib/python3.9/site-packages/ansible_collections/$COLLECTIONS_TO_REMOVE && \
 curl -L -O https://raw.githubusercontent.com/clumio-code/azure-sdk-trim/main/azure_sdk_trim/azure_sdk_trim.py && \
 python azure_sdk_trim.py && rm azure_sdk_trim.py && pip3 uninstall -y humanize && \
-if [[ -n $EXTRARPMS ]]; then microdnf remove -y $EXTRARPMS; fi && mkdir -m 770 -p /pattern/.ansible/tmp /pattern-home/.ansible/tmp
+if [[ -n $EXTRARPMS ]]; then microdnf remove -y $EXTRARPMS; fi && \
+mkdir -p /pattern/.ansible/tmp /pattern-home/.ansible/tmp && \
+find /pattern/.ansible -type d -exec chmod 770 "{}" \; && \
+find /pattern-home/.ansible -type d -exec chmod 770 "{}" \;
 
 # We will have two important folders:
 # /pattern which will have the current pattern's git repo bindmounted

--- a/Containerfile
+++ b/Containerfile
@@ -77,7 +77,7 @@ ansible-galaxy collection install --collections-path /usr/share/ansible/collecti
 rm -rf /usr/local/lib/python3.9/site-packages/ansible_collections/$COLLECTIONS_TO_REMOVE && \
 curl -L -O https://raw.githubusercontent.com/clumio-code/azure-sdk-trim/main/azure_sdk_trim/azure_sdk_trim.py && \
 python azure_sdk_trim.py && rm azure_sdk_trim.py && pip3 uninstall -y humanize && \
-if [[ -n $EXTRARPMS ]]; then microdnf remove -y $EXTRARPMS; fi && \
+if [ -n "$EXTRARPMS" ]; then microdnf remove -y $EXTRARPMS; fi && \
 mkdir -p /pattern/.ansible/tmp /pattern-home/.ansible/tmp && \
 find /pattern/.ansible -type d -exec chmod 770 "{}" \; && \
 find /pattern-home/.ansible -type d -exec chmod 770 "{}" \;

--- a/Containerfile
+++ b/Containerfile
@@ -93,4 +93,4 @@ ENV ANSIBLE_LOCALHOST_WARNING=False
 
 COPY default-cmd.sh /usr/local/bin
 WORKDIR /pattern
-CMD /usr/local/bin/default-cmd.sh
+CMD ["/usr/local/bin/default-cmd.sh"]

--- a/Containerfile
+++ b/Containerfile
@@ -28,7 +28,6 @@ ARG OPENSHIFT_CLIENT_VERSION="4.11.25"
 ARG HELM_VERSION="3.10.3"
 ARG ARGOCD_VERSION="2.5.7"
 ARG TKN_CLI_VERSION="0.29.0"
-ARG KUSTOMIZE_VERSION="4.5.6"
 ARG YQ_VERSION="4.30.7"
 
 # amd64 - arm64
@@ -60,7 +59,6 @@ rm -f /usr/local/bin/README.md && rm -f /usr/local/bin/LICENSE && \
 curl -sLfO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OPENSHIFT_CLIENT_VERSION}/openshift-client-linux-${OPTTARGETARCH}${OPENSHIFT_CLIENT_VERSION}.tar.gz && \
 tar xvf openshift-client-linux-${OPTTARGETARCH}${OPENSHIFT_CLIENT_VERSION}.tar.gz -C /usr/local/bin && \
 rm -rf openshift-client-linux-${OPTTARGETARCH}${OPENSHIFT_CLIENT_VERSION}.tar.gz  && rm -f /usr/local/bin/kubectl && ln -sf /usr/local/bin/oc /usr/local/bin/kubectl && \
-curl -sLfO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz && tar xvf kustomize_v${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz -C /usr/local/bin && rm -f kustomize_v${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz && chmod 755 /usr/local/bin/kustomize && \
 curl -sSL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${TARGETARCH} && chmod 755 /usr/local/bin/yq && \
 rm -rf /root/anaconda* /root/original-ks.cfg /usr/local/README
 

--- a/Containerfile
+++ b/Containerfile
@@ -79,11 +79,7 @@ ansible-galaxy collection install --collections-path /usr/share/ansible/collecti
 rm -rf /usr/local/lib/python3.9/site-packages/ansible_collections/$COLLECTIONS_TO_REMOVE && \
 curl -L -O https://raw.githubusercontent.com/clumio-code/azure-sdk-trim/main/azure_sdk_trim/azure_sdk_trim.py && \
 python azure_sdk_trim.py && rm azure_sdk_trim.py && pip3 uninstall -y humanize && \
-if [[ -n $EXTRARPMS ]]; then microdnf remove -y $EXTRARPMS; fi
-
-#RUN mkdir -m 770 -p /pattern/.ansible/tmp && \
-#chown -R 1001:1001 /pattern  && mkdir -m 770 -p /pattern-home/.ansible/tmp && chown -R 1001:1001 /pattern-home
-RUN mkdir -m 770 -p /pattern/.ansible/tmp && mkdir -m 770 -p /pattern-home/.ansible/tmp
+if [[ -n $EXTRARPMS ]]; then microdnf remove -y $EXTRARPMS; fi && mkdir -m 770 -p /pattern/.ansible/tmp /pattern-home/.ansible/tmp
 
 # We will have two important folders:
 # /pattern which will have the current pattern's git repo bindmounted

--- a/Makefile
+++ b/Makefile
@@ -78,26 +78,28 @@ versions: ## Print all the versions of software in the locally-built container
 		-v ${HOME}:/pattern \
 		-v ${HOME}:${HOME} \
 		-w $$(pwd) "${REGISTRY}/${CONTAINER}-amd64" sh -c \
-		"set -e; echo -n \"python3-pip package \"; rpm -q --queryformat '%{VERSION}\n' python3-pip; \
-		echo -n \"git-core package \"; rpm -q --qf '%{VERSION}\n' git-core; \
-		echo -n \"vi package \"; rpm -q --qf '%{VERSION}\n' vim-minimal; \
-		echo -n \"tar package \"; rpm -q --qf '%{VERSION}\n' tar; \
-		echo -n \"make package \"; rpm -q --qf '%{VERSION}\n' make; \
-		echo -n \"jq package \"; rpm -q --qf '%{VERSION}\n' jq; \
-		echo -n \"argocd binary \"; argocd version --client -o json | jq -r '.client.Version'; \
-		echo -n \"helm binary \"; helm version --short; \
-		echo -n \"tekton binary \"; tkn version --component client; \
-		echo -n \"openshift binary \"; oc version --client -o json | jq -r '.releaseClientVersion'; \
-		echo -n \"kustomize binary \"; oc version --client -o json | jq -r '.kustomizeVersion'; \
-		echo -n \"ansible pip \"; ansible --version -o json | grep core | cut -f3 -d\ | tr -d ']'; \
-		echo -n \"kubernetes pip \"; pip show kubernetes |grep ^Version: | cut -f2 -d\ ; \
-		echo -n \"boto3 pip \"; pip show boto3 | grep ^Version: | cut -f2 -d\ ; \
-		echo -n \"botocore pip \"; pip show botocore | grep ^Version: | cut -f2 -d\ ; \
-		echo -n \"awscli pip \"; pip show awscli | grep ^Version: | cut -f2 -d\ ; \
-		echo -n \"azure-cli pip \"; pip show azure-cli | grep ^Version: | cut -f2 -d\ ; \
-		echo -n \"gcloud pip \"; pip show gcloud| grep ^Version: | cut -f2 -d\ ; \
-		echo -n \"kubernetes.core collection \";  ansible-galaxy collection list kubernetes.core |grep ^kubernetes.core | cut -f2 -d\ ; \
-		echo -n \"redhat_cop.controller_configuration collection \";  ansible-galaxy collection list redhat_cop.controller_configuration |grep ^redhat_cop.controller_configuration | cut -f2 -d\ ; \
+		"set -e; \
+		echo -n \"|python3-pip package \"; rpm -q --queryformat '%{VERSION}' python3-pip; echo \" \"; \
+		echo -n \"|git-core package \"; rpm -q --qf '%{VERSION}' git-core; echo \" \"; \
+		echo -n \"|vi package \"; rpm -q --qf '%{VERSION}' vim-minimal; echo \" \";  \
+		echo -n \"|tar package \"; rpm -q --qf '%{VERSION}' tar;  echo \" \"; \
+		echo -n \"|make package \"; rpm -q --qf '%{VERSION}' make;  echo \" \"; \
+		echo -n \"|python package \"; rpm -q --qf '%{VERSION}' python3;  echo \" \"; \
+		echo -n \"|jq package \"; rpm -q --qf '%{VERSION}' jq;  echo \" \"; \
+		echo -n \"|argocd binary \"; argocd version --client -o json | jq -j '.client.Version';  echo \" \"; \
+		echo -n \"|helm binary \"; helm version --template '{{ .Version }}';  echo \" \"; \
+		echo -n \"|tekton binary \"; tkn version --component client | tr -d '\n';  echo \" \"; \
+		echo -n \"|openshift binary \"; oc version --client -o json | jq -j '.releaseClientVersion';  echo \" \"; \
+		echo -n \"|kustomize binary \"; oc version --client -o json | jq -j '.kustomizeVersion';  echo \" \"; \
+		echo -n \"|ansible pip \"; ansible --version -o json | grep core | cut -f3 -d\ | tr -d '\n]';  echo \" \"; \
+		echo -n \"|kubernetes pip \"; pip show kubernetes |grep ^Version: | cut -f2 -d\ | tr -d '\n';  echo \" \"; \
+		echo -n \"|boto3 pip \"; pip show boto3 | grep ^Version: | cut -f2 -d\ |tr -d '\n';  echo \" \"; \
+		echo -n \"|botocore pip \"; pip show botocore | grep ^Version: | cut -f2 -d\ |tr -d '\n';  echo \" \"; \
+		echo -n \"|awscli pip \"; pip show awscli | grep ^Version: | cut -f2 -d\ |tr -d '\n';  echo \" \"; \
+		echo -n \"|azure-cli pip \"; pip show azure-cli | grep ^Version: | cut -f2 -d\ | tr -d '\n';  echo \" \"; \
+		echo -n \"|gcloud pip \"; pip show gcloud| grep ^Version: | cut -f2 -d\ |tr -d '\n';  echo \" \"; \
+		echo -n \"|kubernetes.core collection \";  ansible-galaxy collection list kubernetes.core |grep ^kubernetes.core | cut -f2 -d\  |tr -d '\n';  echo \" \"; \
+		echo -n \"|redhat_cop.controller_configuration collection \";  ansible-galaxy collection list redhat_cop.controller_configuration |grep ^redhat_cop.controller_configuration | cut -f2 -d\ | tr -d '\n'; echo \" \";  \
     " | sort | column --table -o '|'
 
 .PHONY: run

--- a/Makefile
+++ b/Makefile
@@ -78,34 +78,27 @@ versions: ## Print all the versions of software in the locally-built container
 		-v ${HOME}:/pattern \
 		-v ${HOME}:${HOME} \
 		-w $$(pwd) "${REGISTRY}/${CONTAINER}-amd64" sh -c \
-		"set -e; echo -n \"python3-pip: \"; rpm -q --queryformat '%{VERSION}\n' python3-pip; \
-		echo -n \"git-core: \"; rpm -q --qf '%{VERSION}\n' git-core; \
-		echo -n \"vi: \"; rpm -q --qf '%{VERSION}\n' vim-minimal; \
-		echo -n \"tar: \"; rpm -q --qf '%{VERSION}\n' tar; \
-		echo -n \"make: \"; rpm -q --qf '%{VERSION}\n' make; \
-		echo -n \"jq: \"; rpm -q --qf '%{VERSION}\n' jq; \
-		echo -n \"argocd: \"; argocd version --client -o json | jq -r '.client.Version'; \
-		echo -n \"helm: \"; helm version --short; \
-		echo -n \"tekton: \"; tkn version --component client; \
-		echo -n \"openshift: \"; oc version --client -o json | jq -r '.releaseClientVersion'; \
-		echo -n \"kustomize: \"; oc version --client -o json | jq -r '.kustomizeVersion'; \
-		echo -n \"ansible: \"; ansible --version -o json | grep core | cut -f3 -d\ | tr -d ']'; \
-		echo -n \"kubernetes: \"; pip show kubernetes |grep ^Version: | cut -f2 -d\ ; \
-		echo -n \"boto3: \"; pip show boto3 | grep ^Version: | cut -f2 -d\ ; \
-		echo -n \"botocore: \"; pip show botocore | grep ^Version: | cut -f2 -d\ ; \
-		echo -n \"awscli: \"; pip show awscli | grep ^Version: | cut -f2 -d\ ; \
-		echo -n \"azure-cli: \"; pip show azure-cli | grep ^Version: | cut -f2 -d\ ; \
-		echo -n \"gcloud: \"; pip show gcloud| grep ^Version: | cut -f2 -d\ ; \
-		"
-
-	@podman run --rm -it --net=host \
-		--security-opt label=disable \
-		-v ${HOME}:/pattern \
-		-v ${HOME}:${HOME} \
-		-w $$(pwd) "${REGISTRY}/${CONTAINER}-amd64" sh -c \
-		"set -e; echo -n \"kubenetes.core: \";  ansible-galaxy collection list kubernetes.core |grep ^kubernetes.core | cut -f2 -d\ ; \
-		echo -n \"redhat_cop.controller_configuration: \";  ansible-galaxy collection list redhat_cop.controller_configuration |grep ^redhat_cop.controller_configuration | cut -f2 -d\ ; \
-    "
+		"set -e; echo -n \"python3-pip package \"; rpm -q --queryformat '%{VERSION}\n' python3-pip; \
+		echo -n \"git-core package \"; rpm -q --qf '%{VERSION}\n' git-core; \
+		echo -n \"vi package \"; rpm -q --qf '%{VERSION}\n' vim-minimal; \
+		echo -n \"tar package \"; rpm -q --qf '%{VERSION}\n' tar; \
+		echo -n \"make package \"; rpm -q --qf '%{VERSION}\n' make; \
+		echo -n \"jq package \"; rpm -q --qf '%{VERSION}\n' jq; \
+		echo -n \"argocd binary \"; argocd version --client -o json | jq -r '.client.Version'; \
+		echo -n \"helm binary \"; helm version --short; \
+		echo -n \"tekton binary \"; tkn version --component client; \
+		echo -n \"openshift binary \"; oc version --client -o json | jq -r '.releaseClientVersion'; \
+		echo -n \"kustomize binary \"; oc version --client -o json | jq -r '.kustomizeVersion'; \
+		echo -n \"ansible pip \"; ansible --version -o json | grep core | cut -f3 -d\ | tr -d ']'; \
+		echo -n \"kubernetes pip \"; pip show kubernetes |grep ^Version: | cut -f2 -d\ ; \
+		echo -n \"boto3 pip \"; pip show boto3 | grep ^Version: | cut -f2 -d\ ; \
+		echo -n \"botocore pip \"; pip show botocore | grep ^Version: | cut -f2 -d\ ; \
+		echo -n \"awscli pip \"; pip show awscli | grep ^Version: | cut -f2 -d\ ; \
+		echo -n \"azure-cli pip \"; pip show azure-cli | grep ^Version: | cut -f2 -d\ ; \
+		echo -n \"gcloud pip \"; pip show gcloud| grep ^Version: | cut -f2 -d\ ; \
+		echo -n \"kubernetes.core collection \";  ansible-galaxy collection list kubernetes.core |grep ^kubernetes.core | cut -f2 -d\ ; \
+		echo -n \"redhat_cop.controller_configuration collection \";  ansible-galaxy collection list redhat_cop.controller_configuration |grep ^redhat_cop.controller_configuration | cut -f2 -d\ ; \
+    " | sort | column --table -o '|'
 
 .PHONY: run
 run: ## Runs the container interactively

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,15 @@ run: ## Runs the container interactively
 		-v ${HOME}:${HOME} \
 		-w $$(pwd) "${REGISTRY}/${CONTAINER}-amd64" sh
 
+.PHONY: super-linter
+super-linter: ## Runs super linter locally
+	rm -rf .mypy_cache
+	podman run -e RUN_LOCAL=true -e USE_FIND_ALGORITHM=true	\
+					$(DISABLE_LINTERS) \
+					-v $(PWD):/tmp/lint:rw,z \
+					-w /tmp/lint \
+					docker.io/github/super-linter:slim-v4
+
 .PHONY: upload
 upload: ## Uploads the container to quay.io/hybridcloudpatterns/${CONTAINER}
 	@echo "Uploading the ${REGISTRY}/${CONTAINER} container to ${UPLOADREGISTRY}/${CONTAINER}"

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ run: ## Runs the container interactively
 		--security-opt label=disable \
 		-v ${HOME}:/pattern \
 		-v ${HOME}:${HOME} \
-		-w $$(pwd) "${REGISTRY}/${CONTAINER}" sh
+		-w $$(pwd) "${REGISTRY}/${CONTAINER}-amd64" sh
 
 .PHONY: upload
 upload: ## Uploads the container to quay.io/hybridcloudpatterns/${CONTAINER}

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,18 @@ CONTAINER ?= $(NAME):$(TAG)
 
 REGISTRY ?= localhost
 UPLOADREGISTRY ?= quay.io/rhn_support_mbaldess
+TESTCOMMAND := "set -e; echo '* Helm: '; helm version; \
+		echo '* ArgoCD: '; argocd version --client ; \
+		echo '* Tekton: '; tkn version ; \
+		echo '* oc: '; oc version ; \
+		echo '* kustomize: '; kustomize version ; \
+		echo '* yq: '; yq --version ; \
+		echo '* Python: '; python --version ; \
+		echo '* Ansible: '; ansible --version ; \
+		echo '* kubernetes.core: '; ansible-galaxy collection list | grep kubernetes.core ; \
+		echo '* redhat_cop.controller_configuration: '; ansible-galaxy collection list | grep redhat_cop.controller_configuration ; \
+		echo '* diff: '; diff --version ; \
+		echo '* find: '; find --version"
 
 ##@ Help-related tasks
 .PHONY: help
@@ -47,35 +59,13 @@ podman-build-arm64: ## build the container in arm64
 test-amd64: ## Prints the test of most tools inside the container amd64
 	@echo "** Testing linux/amd64"
 	@podman run --arch=amd64 --rm -it --net=host "${REGISTRY}/${CONTAINER}-amd64" bash -c \
-		"set -e; echo '* Helm: '; helm version; \
-		echo '* ArgoCD: '; argocd version --client ; \
-		echo '* Tekton: '; tkn version ; \
-		echo '* oc: '; oc version ; \
-		echo '* kustomize: '; kustomize version ; \
-		echo '* yq: '; yq --version ; \
-		echo '* Python: '; python --version ; \
-		echo '* Ansible: '; ansible --version ; \
-		echo '* kubernetes.core: '; ansible-galaxy collection list | grep kubernetes.core ; \
-		echo '* redhat_cop.controller_configuration: '; ansible-galaxy collection list | grep redhat_cop.controller_configuration ; \
-		echo '* diff: '; diff --version ; \
-		echo '* find: '; find --version"
+		$(TESTCOMMAND)
 
 .PHONY: test-arm64
 test-arm64: ## Prints the test of most tools inside the container arm64
 	@echo "** Testing linux/arm64"
 	@podman run --arch=arm64 --rm -it --net=host "${REGISTRY}/${CONTAINER}-arm64" bash -c \
-		"set -e; echo '* Helm: '; helm version; \
-		echo '* ArgoCD: '; argocd version --client ; \
-		echo '* Tekton: '; tkn version ; \
-		echo '* oc: '; oc version ; \
-		echo '* kustomize: '; kustomize version ; \
-		echo '* yq: '; yq --version ; \
-		echo '* Python: '; python --version ; \
-		echo '* Ansible: '; ansible --version ; \
-		echo '* kubernetes.core: '; ansible-galaxy collection list | grep kubernetes.core ; \
-		echo '* redhat_cop.controller_configuration: '; ansible-galaxy collection list | grep redhat_cop.controller_configuration ; \
-		echo '* diff: '; diff --version ; \
-		echo '* find: '; find --version"
+		$(TESTCOMMAND)
 
 .PHONY: test
 test: test-amd64 test-arm64 ## Tests the container for all the required bits both arm64 and amd64

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,41 @@ test-arm64: ## Prints the test of most tools inside the container arm64
 test: test-amd64 test-arm64 ## Tests the container for all the required bits both arm64 and amd64
 
 ##@ Run and upload tasks
+.PHONY: versions
+versions: ## Print all the versions of software in the locally-built container
+	@podman run --rm -it --net=host \
+		--security-opt label=disable \
+		-v ${HOME}:/pattern \
+		-v ${HOME}:${HOME} \
+		-w $$(pwd) "${REGISTRY}/${CONTAINER}-amd64" sh -c \
+		"set -e; echo -n \"python3-pip: \"; rpm -q --queryformat '%{VERSION}\n' python3-pip; \
+		echo -n \"git-core: \"; rpm -q --qf '%{VERSION}\n' git-core; \
+		echo -n \"vi: \"; rpm -q --qf '%{VERSION}\n' vim-minimal; \
+		echo -n \"tar: \"; rpm -q --qf '%{VERSION}\n' tar; \
+		echo -n \"make: \"; rpm -q --qf '%{VERSION}\n' make; \
+		echo -n \"jq: \"; rpm -q --qf '%{VERSION}\n' jq; \
+		echo -n \"argocd: \"; argocd version --client -o json | jq -r '.client.Version'; \
+		echo -n \"helm: \"; helm version --short; \
+		echo -n \"tekton: \"; tkn version --component client; \
+		echo -n \"openshift: \"; oc version --client -o json | jq -r '.releaseClientVersion'; \
+		echo -n \"kustomize: \"; oc version --client -o json | jq -r '.kustomizeVersion'; \
+		echo -n \"ansible: \"; ansible --version -o json | grep core | cut -f3 -d\ | tr -d ']'; \
+		echo -n \"kubernetes: \"; pip show kubernetes |grep ^Version: | cut -f2 -d\ ; \
+		echo -n \"boto3: \"; pip show boto3 | grep ^Version: | cut -f2 -d\ ; \
+		echo -n \"botocore: \"; pip show botocore | grep ^Version: | cut -f2 -d\ ; \
+		echo -n \"awscli: \"; pip show awscli | grep ^Version: | cut -f2 -d\ ; \
+		echo -n \"azure-cli: \"; pip show azure-cli | grep ^Version: | cut -f2 -d\ ; \
+		echo -n \"gcloud: \"; pip show gcloud| grep ^Version: | cut -f2 -d\ ; \
+		"
+
+	@podman run --rm -it --net=host \
+		--security-opt label=disable \
+		-v ${HOME}:/pattern \
+		-v ${HOME}:${HOME} \
+		-w $$(pwd) "${REGISTRY}/${CONTAINER}-amd64" sh -c \
+		"set -e; echo -n \"kubenetes.core: \";  ansible-galaxy collection list kubernetes.core |grep ^kubernetes.core | cut -f2 -d\ ; \
+		echo -n \"redhat_cop.controller_configuration: \";  ansible-galaxy collection list redhat_cop.controller_configuration |grep ^redhat_cop.controller_configuration | cut -f2 -d\ ; \
+    "
 
 .PHONY: run
 run: ## Runs the container interactively

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ TESTCOMMAND := "set -e; echo '* Helm: '; helm version; \
 		echo '* ArgoCD: '; argocd version --client ; \
 		echo '* Tekton: '; tkn version ; \
 		echo '* oc: '; oc version ; \
-		echo '* kustomize: '; kustomize version ; \
 		echo '* yq: '; yq --version ; \
 		echo '* Python: '; python --version ; \
 		echo '* Ansible: '; ansible --version ; \

--- a/README.md
+++ b/README.md
@@ -43,6 +43,6 @@ podman run -it --rm --net=host quay.io/hybridcloudpatterns/utility-container:lat
 ## Build the image
 Just run: `make build` and both amd64 and arm64 will be built locally (you will need the qemu-user-static package installed)
 
-To upload the image to the official repo run: `make UPLOADREGISTRY=quay.io/hybridcloudpatterns upload` (by default it uploads somewhere else
+To upload the image to the official repository, run: `make UPLOADREGISTRY=quay.io/hybridcloudpatterns upload` (by default it uploads somewhere else
 to try and avoid accidental uploads)
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,9 @@
-# Validated Pattern Utility Container 
+# Validated Pattern Utility Container
 
 utility container for simplified execution of imperative commands in each of the patterns.
 
-The tag used on the image represents the `oc` client version installed. <br/>
-For example: `quay.io/hybridcloudpatterns/utility-container:stable-4.10.3` means that the openshift client (oc) version is `4.10.3`
 
-```bash
-$ podman run quay.io/hybridcloudpatterns/utility-container:stable-4.10.3` oc version 
-Client Version: 4.10.3
-```
-
-### Installed Software
+## Installed Software
 
 |               name                |  type    |   version    |
 |:---------------------------------:|:--------:|:------------:|
@@ -36,7 +29,7 @@ Client Version: 4.10.3
 |tekton                             |binary    |0.29.0        |
 |vi                                 |package   |8.2.2637      |
 
-### Usage
+## Usage
 **Pull the image**
 ```bash
 podman pull quay.io/hybridcloudpatterns/utility-container:latest
@@ -47,7 +40,7 @@ podman pull quay.io/hybridcloudpatterns/utility-container:latest
 podman run -it --rm --net=host quay.io/hybridcloudpatterns/utility-container:latest ansible-playbook <playbook>.yml
 ```
 
-### Build the image
+## Build the image
 Just run: `make build` and both amd64 and arm64 will be built locally (you will need the qemu-user-static package installed)
 
 To upload the image to the official repo run: `make UPLOADREGISTRY=quay.io/hybridcloudpatterns upload` (by default it uploads somewhere else

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ utility container for simplified execution of imperative commands in each of the
 |:---------------------------------:|:--------:|:------------:|
 |ansible                            |pip       |2.14.4        |
 |argocd                             |binary    |v2.5.7+e0ee345|
-|awscli                             |pip       |1.27.114      |
+|awscli                             |pip       |1.27.115      |
 |azure-cli                          |pip       |2.47.0        |
-|boto3                              |pip       |1.26.114      |
-|botocore                           |pip       |1.29.114      |
+|boto3                              |pip       |1.26.115      |
+|botocore                           |pip       |1.29.115      |
 |gcloud                             |pip       |0.18.3        |
 |git-core                           |package   |2.31.1        |
 |helm                               |binary    |v3.10.3       |

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ Client Version: 4.10.3
 ### Usage
 **Pull the image**
 ```bash
-podman pull quay.io/hybridcloudpatterns/utility-container:stable-4.10.3
+podman pull quay.io/hybridcloudpatterns/utility-container:latest
 ```
 
 **Use image to execute a playbook**
 ```bash
-podman run quay.io/hybridcloudpatterns:stable-4.10.3 ansible-playbook <playbook>.yml 
+podman run -it --rm --net=host quay.io/hybridcloudpatterns/utility-container:latest ansible-playbook <playbook>.yml
 ```
 
 ### Build the image

--- a/README.md
+++ b/README.md
@@ -12,33 +12,29 @@ Client Version: 4.10.3
 
 ### Installed Software
 
-|    name     |  type   |
-|:-----------:|:-------:|
-| python3-pip | package |
-|  git-core   | package |
-|     vi      | package |
-|     tar     | package |
-|    make     | package |
-|     jq      | package |
-|   argocd    | binary  |
-|    helm     | binary  |
-|   tekton    | binary  |
-|  openshift  | binary  |
-|  kustomize  | binary  |
-|   ansible   |   pip   |
-| kubernetes  |   pip   |
-|    boto3    |   pip   |
-|  botocore   |   pip   |
-|   awscli    |   pip   |
-|  azure-cli  |   pip   |
-|   gcloud    |   pip   |
-
-
-### The ansible-galaxy collection installed:
-| ansible-collections |
-| ------------------- |
-| kubernetes.core |
-| redhat_cop.controller_configuration |
+|               name                |  type    |   version    |
+|:---------------------------------:|:--------:|:------------:|
+|ansible                            |pip       |2.14.4        |
+|argocd                             |binary    |v2.5.7+e0ee345|
+|awscli                             |pip       |1.27.114      |
+|azure-cli                          |pip       |2.47.0        |
+|boto3                              |pip       |1.26.114      |
+|botocore                           |pip       |1.29.114      |
+|gcloud                             |pip       |0.18.3        |
+|git-core                           |package   |2.31.1        |
+|helm                               |binary    |v3.10.3       |
+|jq                                 |package   |1.6           |
+|kubernetes.core                    |collection|2.4.0         |
+|kubernetes                         |pip       |26.1.0        |
+|kustomize                          |binary    |v4.5.4        |
+|make                               |package   |4.3           |
+|openshift                          |binary    |4.11.25       |
+|python3-pip                        |package   |21.2.3        |
+|python                             |package   |3.9.14        |
+|redhat_cop.controller_configuration|collection|2.3.1         |
+|tar                                |package   |1.34          |
+|tekton                             |binary    |0.29.0        |
+|vi                                 |package   |8.2.2637      |
 
 ### Usage
 **Pull the image**


### PR DESCRIPTION
- Small cleanup
- Use amd64 to run the container locally in the run target
- Drop kustomize from the container
- Add a versions target
- Unify the test commands into a single variable
- Amend versions target
- Complete the versions target and add versions to README.md
- Fix README to use last container
- Add superlinter workflow testwise
- Clean up README.md and drop incorrect info
- Silence some warnings
- Use JSON syntax for CMD commands
- Tag ubi9 latest explicitely
- Be more explicit in changing folder permissions
- Add hadolint exception list
- Add DL3007 to exception list
- Be more posix compliant
- Drop kustomize for real
- Update tools versions in README
